### PR TITLE
updating install strat for es module

### DIFF
--- a/pgbench/Dockerfile
+++ b/pgbench/Dockerfile
@@ -6,7 +6,9 @@ RUN rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/
 RUN yum -y update
 RUN yum install -y postgresql11
 RUN yum install -y redis
-RUN yum install -y python-elasticsearch
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
 RUN yum install -y numpy
 RUN ln -s /usr/pgsql-11/bin/pgbench /usr/bin/pgbench
 RUN git clone https://github.com/cloud-bulldozer/snafu /opt/snafu

--- a/uperf/Dockerfile
+++ b/uperf/Dockerfile
@@ -7,6 +7,6 @@ RUN yum --enablerepo=ndokos-pbench install -y pbench-uperf
 RUN yum install -y redis
 RUN yum install -y git python-pip
 RUN pip install --upgrade pip
-RUN pip install -y "elasticsearch>=6.0.0,<=7.0.2"
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
 RUN yum install -y numpy
 RUN git clone https://github.com/cloud-bulldozer/snafu /opt/snafu

--- a/ycsb/Dockerfile
+++ b/ycsb/Dockerfile
@@ -7,7 +7,8 @@ RUN curl -O --location https://github.com/brianfrankcooper/YCSB/releases/downloa
 RUN mkdir ycsb
 RUN tar xzf ycsb-0.15.0.tar.gz -C ycsb --strip-components 1
 RUN yum install -y redis
-RUN yum install -y python-elasticsearch
+RUN yum install -y git python-pip
+RUN pip install --upgrade pip
+RUN pip install "elasticsearch>=6.0.0,<=7.0.2"
 RUN yum install -y numpy
-RUN yum install -y git
 RUN git clone https://github.com/cloud-bulldozer/snafu /opt/snafu


### PR DESCRIPTION
Making sure that we're using the right python package for elasticsearch,
so that snafu can send results to a es host thats v6 and v7 as well.