### PR TITLE
fs-drift

### DIFF
--- a/fs-drift/Dockerfile
+++ b/fs-drift/Dockerfile
@@ -2,13 +2,7 @@ FROM centos/tools
 
 USER root
 WORKDIR /root/
-RUN yum install -y python2-elasticsearch python2-numpy python2-redis
+RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install -y git python2-elasticsearch6 python2-redis python2-numpy
 RUN git clone https://github.com/parallel-fs-utils/fs-drift
 RUN git clone https://github.com/cloud-bulldozer/snafu /opt/snafu
-# if you want to run fs-drift as a distributed workload from 
-# a single control point (like fio), with shared filesystem storage,
-# use launch.sh as described in fs-drift documentation.
-# if the environment variables for this pod aren't set
-# then launch.sh will exit immediately and is a noop
-RUN ln -sv /root/fs-drift/fs-drift-remote.py /usr/local/bin
-CMD fs-drift/examples/docker/fs-drift/launch.sh

--- a/fs-drift/Dockerfile
+++ b/fs-drift/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos/tools
+
+USER root
+WORKDIR /root/
+RUN yum install -y python2-elasticsearch python2-numpy python2-redis
+RUN git clone https://github.com/parallel-fs-utils/fs-drift
+RUN git clone https://github.com/cloud-bulldozer/snafu /opt/snafu
+# if you want to run fs-drift as a distributed workload from 
+# a single control point (like fio), with shared filesystem storage,
+# use launch.sh as described in fs-drift documentation.
+# if the environment variables for this pod aren't set
+# then launch.sh will exit immediately and is a noop
+RUN ln -sv /root/fs-drift/fs-drift-remote.py /usr/local/bin
+CMD fs-drift/examples/docker/fs-drift/launch.sh


### PR DESCRIPTION
Should I do this first, then do PR for ripsaw after, so that I can reference this image in my ripsaw PR?  Is it ok to use python2 for now?  fs-drift runs in python3 also but centos7 just doesn't have python3 RPM images for things like elasticsearch, and I didn't want to get into pip installs.  When centos8 comes out, I'll upgrade to python3 then.